### PR TITLE
remove vendor plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "BSD-2-Clause",
     "type": "silverstripe-vendormodule",
     "require": {
-        "silverstripe/vendor-plugin": "^2.0",
         "silverstripe/framework": "^6"
     },
     "require-dev": {


### PR DESCRIPTION
Vendor plugin is not needed, as it's an indirect requirement with SilverStripe framework